### PR TITLE
Fix Blog Entries Total Count

### DIFF
--- a/app/view_models/workarea/storefront/blog_view_model.rb
+++ b/app/view_models/workarea/storefront/blog_view_model.rb
@@ -40,7 +40,7 @@ module Workarea
       end
 
       def total
-        @total ||= scoped_entries.count
+        @total ||= scoped_entries.total_count
       end
 
       def page

--- a/test/view_models/workarea/storefront/blog_view_model_test.rb
+++ b/test/view_models/workarea/storefront/blog_view_model_test.rb
@@ -143,6 +143,29 @@ module Workarea
             refute newly_published.empty?
           end
         end
+
+        def test_total
+          release = create_release(publish_at: 1.hour.from_now, published_at: nil)
+          26.times do
+            @blog.entries.create!(name: 'Test', author: 'BC', active: true)
+            @blog.entries.create!(name: 'Unpublished', author: 'BC', active: false)
+          end
+          release.as_current do
+            @blog.entries.where(name: 'Unpublished').each do |entry|
+              entry.update!(active: true)
+            end
+          end
+
+          view_model = Workarea::Storefront::BlogViewModel.new(@blog)
+
+          assert_equal(26, view_model.total)
+
+          release.as_current do
+            view_model = Workarea::Storefront::BlogViewModel.new(@blog.reload)
+
+            assert_equal(52, view_model.total)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The `#total` method on `Storefront::BlogEntryViewModel` was not
returning the actual total amount of entries if they exceeded 25, due to
Kaminari's default pagination. Use `scoped_entries.total_count` here to
avoid the problem.