### PR TITLE
Fix Content Search Text for Blog Entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+on: [push]
+
+jobs:
+  static_analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: workarea-commerce/ci/bundler-audit@v1
+    - uses: workarea-commerce/ci/rubocop@v1
+
+  admin_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bin/rails app:workarea:test:admin
+
+  core_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bin/rails app:workarea:test:core
+
+  storefront_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bin/rails app:workarea:test:storefront
+
+  plugins_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bin/rails app:workarea:test:plugins

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_from:
+  - https://raw.githubusercontent.com/workarea-commerce/workarea/master/.rubocop.yml
+

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "stylelint-config-recommended-scss",
+  "rules": {
+    "block-no-empty": null,
+    "no-descending-specificity": null,
+    "property-no-unknown": [true, { "ignoreProperties": ["mso-hide"] }]
+  }
+}

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem 'listen'
 gem 'workarea'
+gem 'workarea-content_search'

--- a/app/models/workarea/search/storefront/content.decorator
+++ b/app/models/workarea/search/storefront/content.decorator
@@ -1,0 +1,12 @@
+module Workarea
+  if Plugin.installed?(:content_search)
+    decorate Search::Storefront::Content, with: :blog do
+      # Always use the summary
+      def text
+        return super unless model.contentable.try(:summary).present?
+
+        model.contentable.summary
+      end
+    end
+  end
+end

--- a/test/models/workarea/search/storefront/blog_content_test.rb
+++ b/test/models/workarea/search/storefront/blog_content_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+module Workarea
+  if Plugin.installed?(:content_search)
+    module Search
+      class Storefront
+        class BlogContentTest < Workarea::TestCase
+          include TestCase::SearchIndexing
+
+          setup :setup_models
+
+          def setup_models
+            @entry = create_blog_entry(blog: create_blog)
+            @content = Workarea::Content.for(@entry)
+            @content.blocks.create!(
+              type: :html,
+              data: { 'html' => '<p>lorem ipsum dolor sit amet</p</p>' }
+            )
+          end
+
+          def test_use_summary_for_text_when_available
+            @entry.update!(summary: 'foo bar baz')
+            indexed = Content.new(@content)
+
+            assert_equal('foo bar baz', indexed.text)
+          end
+
+          def test_fall_back_to_default_block_text_extraction
+            indexed = Content.new(@content)
+
+            assert_equal('lorem ipsum dolor sit amet', indexed.text)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since workarea-commerce/workarea-content-search#1 seems to be on the
back burner for now, and regardless of this blogs will have to handle
their search summary text on their own anyway. Update
`Search::Storefront::Content` to use the blog entry summary if it
exists, falling back to whatever the content-search gem uses to generate
its text. At the moment, this involves extracting text from content
blocks that have more than 5 words in them, but this may change in the
next major.

(#6)