### PR TITLE
Replace usage of Content::Asset#placeholder with #image_placeholder

### DIFF
--- a/app/view_models/workarea/admin/blog_entry_view_model.rb
+++ b/app/view_models/workarea/admin/blog_entry_view_model.rb
@@ -18,7 +18,7 @@ module Workarea
           hash[key] = begin
                         Content::Asset.find(id)
                       rescue StandardError
-                        Content::Asset.placeholder
+                        Content::Asset.image_placeholder
                       end
         end
 

--- a/app/view_models/workarea/storefront/blog_entry_view_model.rb
+++ b/app/view_models/workarea/storefront/blog_entry_view_model.rb
@@ -29,7 +29,7 @@ module Workarea
         @assets[id.to_s] = begin
                              Content::Asset.find(id)
                            rescue StandardError
-                             Content::Asset.placeholder
+                             Content::Asset.image_placeholder
                            end
       end
 

--- a/lib/workarea/blog/import/wordpress/content_cleaner.rb
+++ b/lib/workarea/blog/import/wordpress/content_cleaner.rb
@@ -31,7 +31,7 @@ module Workarea
 
           def find_asset(uri)
             name = uri.path.rpartition('.').first.split('/').join('-')
-            Content::Asset.find_by(name: name) rescue Content::Asset.placeholder
+            Content::Asset.find_by(name: name) rescue Content::Asset.image_placeholder
           end
 
           def make_internal_links_relative


### PR DESCRIPTION
Workarea v3.5 removes the #placeholder method in favor of the more
specific #image_placeholder

BLOG-10