### PR TITLE
Fix Deprecation Warnings When Querying Entries

### DIFF
--- a/app/view_models/workarea/storefront/blog_view_model.rb
+++ b/app/view_models/workarea/storefront/blog_view_model.rb
@@ -48,7 +48,7 @@ module Workarea
       end
 
       def updated_at
-        @updated_at ||= model.entries.active.newest.first.try(:updated_at)
+        @updated_at ||= model.entries.newest.select(&:active?).first.try(:updated_at)
       end
 
       private
@@ -58,7 +58,7 @@ module Workarea
       end
 
       def scoped_entries
-        return scoped_entries_from_database if current_release.published?
+        return scoped_entries_from_database.page unless Release.current.present?
 
         Kaminari.paginate_array(scoped_entries_filtered_by_current_release)
       end
@@ -68,7 +68,7 @@ module Workarea
       end
 
       def scoped_entries_from_database
-        scope = ordered_entries.active
+        scope = ordered_entries.where(active: true)
         scope = scope.tagged_with(options[:tag]) if options[:tag].present?
         scope
       end

--- a/config/initializers/content_block_types.rb
+++ b/config/initializers/content_block_types.rb
@@ -1,4 +1,4 @@
-Workarea::Content.define_block_types do
+Workarea.define_content_block_types do
   block_type 'Blog Entry' do
     description 'Feature a blog entry as a content block'
     view_model 'Workarea::Storefront::ContentBlocks::BlogEntryContentBlockViewModel'

--- a/test/view_models/workarea/storefront/blog_view_model_test.rb
+++ b/test/view_models/workarea/storefront/blog_view_model_test.rb
@@ -133,15 +133,16 @@ module Workarea
           unpublished = view_model.entries.select { |entry| entry.name == 'Unpublished' }
 
           assert_equal(3, view_model.entries.count)
-          assert unpublished.empty?
+          assert(unpublished.empty?)
+          assert(release.publish!)
 
-          release.as_current do
-            view_model = Workarea::Storefront::BlogViewModel.new(@blog.reload)
-            newly_published = view_model.entries.select { |entry| entry.name == 'Unpublished' }
-
-            assert_equal(4, view_model.entries.count)
-            refute newly_published.empty?
+          view_model = Workarea::Storefront::BlogViewModel.new(@blog.reload)
+          newly_published = view_model.entries.select do |entry|
+            entry.name == 'Unpublished'
           end
+
+          assert_equal(4, view_model.entries.count)
+          refute(newly_published.empty?)
         end
 
         def test_total


### PR DESCRIPTION
Use the `.select(&:active?)` format instead of the `.active` scope on
blog entries so that segmentation and releases are respected.

BLOG-11