### PR TITLE
Improve test related to content search

### DIFF
--- a/test/models/workarea/search/storefront/blog_content_test.rb
+++ b/test/models/workarea/search/storefront/blog_content_test.rb
@@ -20,13 +20,13 @@ module Workarea
 
           def test_use_summary_for_text_when_available
             @entry.update!(summary: 'foo bar baz')
-            indexed = Content.new(@content)
+            indexed = Content.new(@content.reload)
 
             assert_equal('foo bar baz', indexed.text)
           end
 
           def test_fall_back_to_default_block_text_extraction
-            indexed = Content.new(@content)
+            indexed = Content.new(@content.reload)
 
             assert_equal('lorem ipsum dolor sit amet', indexed.text)
           end


### PR DESCRIPTION
If another plugin decorates in a way to cause a `Content` to load its `Contentable` during creation/update (e.g. in a callback), this test will fail because the `Content` doesn't reload its `Contentable`.

This was noticied when combined with the site builder plugin.