### PR TITLE
Ruby 3.x compatibility: replace deprecated APIs, add gemspec ruby constraint

### DIFF
--- a/app/controllers/workarea/admin/content_blog_comments_controller.rb
+++ b/app/controllers/workarea/admin/content_blog_comments_controller.rb
@@ -12,7 +12,7 @@ module Workarea
       def edit; end
 
       def update
-        if @blog_comment.update_attributes(blog_comment_params)
+        if @blog_comment.update(blog_comment_params)
           flash[:success] = 'Blog entry comment has been updated'
           redirect_to content_blog_user_comments_path(
             content_blog_entry_id: params[:content_blog_entry_id]

--- a/app/controllers/workarea/admin/content_blog_entries_controller.rb
+++ b/app/controllers/workarea/admin/content_blog_entries_controller.rb
@@ -26,7 +26,7 @@ module Workarea
       end
 
       def update
-        if @blog_entry.update_attributes(params[:blog_entry])
+        if @blog_entry.update(params[:blog_entry])
           flash[:success] = t('workarea.admin.content_blog_entries.flash_messages.updated')
           redirect_to edit_content_blog_entry_path(@blog_entry)
         else
@@ -40,7 +40,7 @@ module Workarea
       end
 
       def update_thumbnail_image
-        if @blog_entry.update_attributes(params[:blog_entry])
+        if @blog_entry.update(params[:blog_entry])
           flash[:success] = t('workarea.admin.content_blog_entries.flash_messages.updated')
           redirect_to thumbnail_image_content_blog_entry_path(@blog_entry)
         else

--- a/app/controllers/workarea/admin/content_blogs_controller.rb
+++ b/app/controllers/workarea/admin/content_blogs_controller.rb
@@ -23,7 +23,7 @@ module Workarea
       end
 
       def update
-        if @blog.update_attributes(blog_params)
+        if @blog.update(blog_params)
           flash[:success] = 'Blog has been updated'
           redirect_to edit_content_blog_path(@blog)
         else

--- a/app/controllers/workarea/admin/create_content_blog_entries_controller.rb
+++ b/app/controllers/workarea/admin/create_content_blog_entries_controller.rb
@@ -25,7 +25,7 @@ module Workarea
       end
 
       def save_thumbnail_image
-        @blog_entry.update_attributes(params[:blog_entry])
+        @blog_entry.update(params[:blog_entry])
         redirect_to content_create_content_blog_entry_path(@blog_entry)
       end
 

--- a/app/controllers/workarea/storefront/blog_entries_controller.rb
+++ b/app/controllers/workarea/storefront/blog_entries_controller.rb
@@ -20,7 +20,7 @@ module Workarea
             flash[:error] = 'First and last name are required'
             render(:show) && return
           else
-            current_user.update_attributes(params.permit(:first_name, :last_name))
+            current_user.update(params.permit(:first_name, :last_name))
           end
         end
 

--- a/test/integration/workarea/blog/create_blog_entries_integration_test.rb
+++ b/test/integration/workarea/blog/create_blog_entries_integration_test.rb
@@ -73,7 +73,7 @@ module Workarea
 
         assert(entry.reload.active?)
 
-        entry.update_attributes(active: false)
+        entry.update(active: false)
 
         post admin.save_publish_create_content_blog_entry_path(entry),
              params: { activate: 'new_release', release: { name: '' } }
@@ -93,7 +93,7 @@ module Workarea
         release.as_current { assert(entry.reload.active?) }
 
         release = create_release
-        entry.update_attributes!(active: false)
+        entry.update!(active: false)
 
         post admin.save_publish_create_content_blog_entry_path(entry),
              params: { activate: release.id }

--- a/test/integration/workarea/blog/storefront_integration_test.rb
+++ b/test/integration/workarea/blog/storefront_integration_test.rb
@@ -61,7 +61,7 @@ module Workarea
         login_user
         entry = @blog.entries.first
 
-        @user.update_attributes(first_name: nil, last_name: nil)
+        @user.update(first_name: nil, last_name: nil)
 
         post storefront.blog_entry_comment_path(entry), params: {
           body: 'test comment',
@@ -77,7 +77,7 @@ module Workarea
       def test_raises_invalid_display_unless_the_entry_is_active
         entry = @blog.entries.first
 
-        entry.update_attributes!(active: false)
+        entry.update!(active: false)
         assert_raises(InvalidDisplay) { get storefront.blog_entry_path(entry) }
       end
 

--- a/test/system/workarea/storefront/blog_system_test.rb
+++ b/test/system/workarea/storefront/blog_system_test.rb
@@ -172,7 +172,7 @@ module Workarea
         assert_equal(storefront.blog_entry_path(blog.entries.first), current_path)
         assert(page.has_content?('Success'))
 
-        Workarea::Content::BlogComment.first.update_attributes(approved: true)
+        Workarea::Content::BlogComment.first.update(approved: true)
 
         clear_driver_cache if respond_to?(:clear_driver_cache)
         visit storefront.blog_entry_path(blog.entries.first)
@@ -190,7 +190,7 @@ module Workarea
         Workarea::Content::BlogComment
           .where(body: 'test comment 2')
           .first
-          .update_attributes!(approved: true)
+          .update!(approved: true)
 
         clear_driver_cache if respond_to?(:clear_driver_cache)
         visit storefront.blog_entry_path(blog.entries.first)

--- a/workarea-blog.gemspec
+++ b/workarea-blog.gemspec
@@ -15,5 +15,7 @@ Gem::Specification.new do |s|
 
   s.license = 'Business Software License'
 
+  s.required_ruby_version = ['>= 2.7', '< 3.5']
+
   s.add_dependency 'workarea', '~> 3.x', '>= 3.5.x'
 end


### PR DESCRIPTION
## Ruby 3.x Compatibility

### Changes
- Replace `update_attributes`/`update_attributes!` with `update`/`update!` (removed in Rails 6.1+)
- Add `required_ruby_version = '>= 2.7', '< 3.5'` to gemspec

### Verification
```sh
grep -rn 'update_attributes\|Dir\.exists?\|URI\.escape' --include='*.rb' . | grep -v vendor
# Returns no output
```

### Related
Closes workarea-commerce/workarea#676

Client impact: None — backward compatible